### PR TITLE
Compile using javac -release option

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Users should feel free to add their own handlers outputting metrics or JSON to t
 # Compatibility
 This is provided as a separate library, to make it easier to use against various versions of the Couchbase SDKs.
 
-It should be compatible with the Couchbase Java, Kotlin and Scala SDKs.  The library is written in JDK 8 to maximise compatibility.
+It should be compatible with the Couchbase Java, Kotlin and Scala SDKs.  Building the library from source requires JDK 9 or later.  At runtime, Java 8 or later is required.
 
 The SDK interfaces this library relies on have been stable from core-io 2.3.4 onwards (core-io is the library shared by all Couchbase JVM SDKs), and so this library is expected to work without issue against Java SDK 3.3.4 onwards, Scala SDK 1.3.4 onwards, and Kotlin SDK 1.0.4 onwards.
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,7 @@
     </dependencies>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
With `maven.compiler.target`, it's possible to accidentally use Java 9+ APIs if Java 9+ JDK is used at build time. Setting `maven.compiler.release` instead guarantees the code uses only Java 8 APIs.