### PR TITLE
Add missing nullability annotations

### DIFF
--- a/src/main/java/com/couchbase/client/operations/Operations.java
+++ b/src/main/java/com/couchbase/client/operations/Operations.java
@@ -135,8 +135,9 @@ public class Operations {
     HashMap<String, Integer> exceptionCounts = new HashMap<>();
 
     operations.forEach(op -> {
-      if (op.spans().span().exception() != null) {
-        String exceptionName = op.spans().span().exception().getClass().getSimpleName();
+      Throwable exception = op.spans().span().exception();
+      if (exception != null) {
+        String exceptionName = exception.getClass().getSimpleName();
         exceptionCounts.merge(exceptionName, 1, Integer::sum);
       }
     });

--- a/src/main/java/com/couchbase/client/operations/package-info.java
+++ b/src/main/java/com/couchbase/client/operations/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package com.couchbase.client.operations;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/com/couchbase/client/package-info.java
+++ b/src/main/java/com/couchbase/client/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package com.couchbase.client;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/com/couchbase/client/spans/InMemoryRequestSpan.java
+++ b/src/main/java/com/couchbase/client/spans/InMemoryRequestSpan.java
@@ -35,7 +35,7 @@ import java.util.HashMap;
 @Stability.Internal
 public class InMemoryRequestSpan implements RequestSpan {
   private final String name;
-  private final InMemoryRequestSpan parent;
+  private final @Nullable InMemoryRequestSpan parent;
   private final long startNanos = System.nanoTime();
   private long endNanos = System.nanoTime();
   private final ZonedDateTime startLocal = ZonedDateTime.now();
@@ -43,7 +43,7 @@ public class InMemoryRequestSpan implements RequestSpan {
   private @Nullable Throwable exception = null;
   private RequestSpan.@Nullable StatusCode status;
 
-  public InMemoryRequestSpan(String name, InMemoryRequestSpan parent) {
+  public InMemoryRequestSpan(String name, @Nullable InMemoryRequestSpan parent) {
     this.name = name;
     this.parent = parent;
   }
@@ -92,7 +92,7 @@ public class InMemoryRequestSpan implements RequestSpan {
     return name;
   }
 
-  public InMemoryRequestSpan parent() {
+  public @Nullable InMemoryRequestSpan parent() {
     return parent;
   }
 
@@ -132,8 +132,7 @@ public class InMemoryRequestSpan implements RequestSpan {
     return attributes.get(key);
   }
 
-  @Nullable
-  public Throwable exception() {
+  public @Nullable Throwable exception() {
     return exception;
   }
 

--- a/src/main/java/com/couchbase/client/spans/package-info.java
+++ b/src/main/java/com/couchbase/client/spans/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package com.couchbase.client.spans;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/com/couchbase/client/util/package-info.java
+++ b/src/main/java/com/couchbase/client/util/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package com.couchbase.client.util;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
Motivation
----------
Want all types to default to `@NonNull`.

Modifications
-------------
Annotate all packages as `@NullMarked`.
Without this annotation, the compiler doesn't
warn about storing null in an unannotated type.

Annotate InMemoryRequestSpan.parent as nullable.

Avoid null warning in Operations.exceptionStats()
by storing method result in a local variable
before checking for null.