### PR TITLE
Use Instant to represent point in time

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,13 +171,13 @@ The `ExampleHandlers::writeAllOperations` handler, which can be enabled to run (
 [ {
   "name" : "query",
   "service" : "query",
-  "start" : "2025-01-13T14-34-57.397Z",
+  "start" : "2025-01-13T14:34:57.397123Z",
   "durationUs" : 33504,
   "statement" : "SELECT 'hello' AS GREETING",
   "retries" : 0,
   "networkCalls" : [ {
     "durationUs" : 7372,
-    "start" : "2025-01-13T14-34-57.402Z",
+    "start" : "2025-01-13T14:34:57.402123Z",
     "host" : "192.168.0.99",
     "port" : 8093
   } ]
@@ -190,14 +190,14 @@ While this is the output from a single failure query:
 [ {
   "name" : "query",
   "service" : "query",
-  "start" : "2025-01-13T14-55-03.375Z",
+  "start" : "2025-01-13T14:55:03.375123Z",
   "durationUs" : 54476,
   "statement" : "BAD SQL++ TO FORCE A FAILURE",
   "exception" : "com.couchbase.client.core.error.ParsingFailureException: Parsing of the input failed {\"completed\":true,\"coreId\":\"0x5685c00c00000001\",\"errors\":[{\"additional\":{\"line\":1,\"column\":5},\"code\":3000,\"message\":\"syntax error - line 1, column 5, near 'BAD ', at: SQL\",\"retry\":false}],\"httpStatus\":400,\"idempotent\":false,\"lastDispatchedFrom\":\"192.168.1.120:58521\",\"lastDispatchedTo\":\"192.168.0.99:8093\",\"requestId\":5,\"requestType\":\"QueryRequest\",\"retried\":0,\"service\":{\"operationId\":\"null\",\"statement\":\"BAD SQL++ TO FORCE A FAILURE\",\"type\":\"query\"},\"timeoutMs\":75000,\"timings\":{\"dispatchMicros\":9378,\"totalDispatchMicros\":9378,\"totalMicros\":52305}}",
   "retries" : 0,
   "networkCalls" : [ {
     "durationUs" : 9371,
-    "start" : "2025-01-13T14-55-03.382Z",
+    "start" : "2025-01-13T14:55:03.382123Z",
     "host" : "192.168.0.99",
     "port" : 8093
   } ]
@@ -209,7 +209,7 @@ And the output from a single successful KV operation:
 [ {
   "name" : "upsert",
   "service" : "kv",
-  "start" : "2025-01-13T14-59-25.275Z",
+  "start" : "2025-01-13T14:59:25.275123Z",
   "durationUs" : 27169,
   "documentId" : "id",
   "bucket" : "default",
@@ -218,11 +218,11 @@ And the output from a single successful KV operation:
   "retries" : 0,
   "requestEncoding" : {
     "durationUs" : 3315,
-    "start" : "2025-01-13T14-59-25.275Z"
+    "start" : "2025-01-13T14:59:25.275123Z"
   },
   "networkCalls" : [ {
     "durationUs" : 13081,
-    "start" : "2025-01-13T14-59-25.286Z",
+    "start" : "2025-01-13T14:59:25.286123Z",
     "host" : "192.168.0.99",
     "port" : 11210,
     "durability" : "NONE",

--- a/src/main/java/com/couchbase/client/ExampleHandlers.java
+++ b/src/main/java/com/couchbase/client/ExampleHandlers.java
@@ -29,8 +29,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.time.ZonedDateTime;
-
-import static com.couchbase.client.util.OperationsToJson.FORMATTER;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Example handlers for the in-memory request tracer.
@@ -41,6 +40,8 @@ import static com.couchbase.client.util.OperationsToJson.FORMATTER;
 @Stability.Volatile
 public class ExampleHandlers {
   private static final Logger logger = LoggerFactory.getLogger(ExampleHandlers.class);
+
+  private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss.SSSX");
 
   private ExampleHandlers() {
   }

--- a/src/main/java/com/couchbase/client/operations/NetworkCall.java
+++ b/src/main/java/com/couchbase/client/operations/NetworkCall.java
@@ -21,7 +21,9 @@ import com.couchbase.client.spans.InMemoryRequestSpan;
 import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
+
+import static com.couchbase.client.util.DurationUtil.durationOfMicros;
 
 /**
  * A {@link Operation} can consist of zero or more underlying network calls.  Each is represented by an instance of this class.
@@ -48,7 +50,7 @@ public class NetworkCall {
   public @Nullable Duration serverDuration() {
     Object serverDuration = span.attribute(TracingIdentifiers.ATTR_SERVER_DURATION);
     if (serverDuration instanceof Long) {
-      return Duration.ofNanos((Long) serverDuration * 1000);
+      return durationOfMicros((Long) serverDuration);
     }
     return null;
   }
@@ -63,8 +65,8 @@ public class NetworkCall {
   /**
    * When this network call started, from the SDK's point of view.
    */
-  public ZonedDateTime start() {
-    return span.startLocal();
+  public Instant start() {
+    return span.startInstant();
   }
 
   /**

--- a/src/main/java/com/couchbase/client/operations/Operation.java
+++ b/src/main/java/com/couchbase/client/operations/Operation.java
@@ -23,7 +23,7 @@ import com.couchbase.client.spans.SpansForOperation;
 import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.stream.Collectors;
 
 /**
@@ -97,7 +97,7 @@ public class Operation {
   /**
    * Returns when the operation started, from the SDK's point of view.
    */
-  public ZonedDateTime start() {
+  public Instant start() {
     return spans.start();
   }
 

--- a/src/main/java/com/couchbase/client/operations/Operations.java
+++ b/src/main/java/com/couchbase/client/operations/Operations.java
@@ -15,8 +15,8 @@
  */
 package com.couchbase.client.operations;
 
-import com.couchbase.client.InMemoryRequestTracerHandlerOperations;
 import com.couchbase.client.Durations;
+import com.couchbase.client.InMemoryRequestTracerHandlerOperations;
 import com.couchbase.client.core.annotation.Stability;
 import com.couchbase.client.core.cnc.TracingIdentifiers;
 import com.couchbase.client.spans.InMemoryRequestSpan;
@@ -29,6 +29,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.couchbase.client.util.DurationUtil.toMicros;
 
 /**
  * Wraps a list of {@link Operation} instances.
@@ -125,7 +127,7 @@ public class Operations {
    * in this object, in microseconds.
    */
   public Durations durationsMicroseconds() {
-    return new Durations(operations.stream().map((o -> (o.duration().toNanos()) / 1000)));
+    return new Durations(operations.stream().map(o -> toMicros(o.duration())));
   }
 
   /**

--- a/src/main/java/com/couchbase/client/operations/RequestEncoding.java
+++ b/src/main/java/com/couchbase/client/operations/RequestEncoding.java
@@ -19,7 +19,7 @@ import com.couchbase.client.core.annotation.Stability;
 import com.couchbase.client.spans.InMemoryRequestSpan;
 
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 /**
  * An operation generally needs to encode the request before sending it over the wire, which is represented by this class.
@@ -50,7 +50,7 @@ public class RequestEncoding {
   /**
    * When this network call started, from the SDK's point of view.
    */
-  public ZonedDateTime start() {
-    return span().startLocal();
+  public Instant start() {
+    return span().startInstant();
   }
 }

--- a/src/main/java/com/couchbase/client/operations/RequestEncodings.java
+++ b/src/main/java/com/couchbase/client/operations/RequestEncodings.java
@@ -20,6 +20,8 @@ import com.couchbase.client.core.annotation.Stability;
 
 import java.util.List;
 
+import static com.couchbase.client.util.DurationUtil.toMicros;
+
 /**
  * Represents a number of {@link RequestEncoding}.
  */
@@ -37,7 +39,7 @@ public class RequestEncodings {
    * in this object, in microseconds.
    */
   public Durations durationsMicroseconds() {
-    return new Durations(requestEncodingSpans.stream().map((o -> (o.duration().toNanos()) / 1000)));
+    return new Durations(requestEncodingSpans.stream().map(o -> toMicros(o.duration())));
   }
 
   /**

--- a/src/main/java/com/couchbase/client/spans/InMemoryRequestSpan.java
+++ b/src/main/java/com/couchbase/client/spans/InMemoryRequestSpan.java
@@ -22,7 +22,6 @@ import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZonedDateTime;
 import java.util.HashMap;
 
 /**
@@ -38,7 +37,7 @@ public class InMemoryRequestSpan implements RequestSpan {
   private final InMemoryRequestSpan parent;
   private final long startNanos = System.nanoTime();
   private long endNanos = System.nanoTime();
-  private final ZonedDateTime startLocal = ZonedDateTime.now();
+  private final Instant startInstant = Instant.now();
   private final HashMap<String, Object> attributes = new HashMap<>();
   private @Nullable Throwable exception = null;
   private RequestSpan.@Nullable StatusCode status;
@@ -100,8 +99,8 @@ public class InMemoryRequestSpan implements RequestSpan {
     return startNanos;
   }
 
-  public ZonedDateTime startLocal() {
-    return startLocal;
+  public Instant startInstant() {
+    return startInstant;
   }
 
   public long endNanos() {

--- a/src/main/java/com/couchbase/client/spans/SpansForOperation.java
+++ b/src/main/java/com/couchbase/client/spans/SpansForOperation.java
@@ -18,7 +18,7 @@ package com.couchbase.client.spans;
 import com.couchbase.client.core.annotation.Stability;
 
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -52,7 +52,7 @@ public class SpansForOperation {
     return span.duration();
   }
 
-  public ZonedDateTime start() {
-    return span.startLocal();
+  public Instant start() {
+    return span.startInstant();
   }
 }

--- a/src/main/java/com/couchbase/client/util/DurationUtil.java
+++ b/src/main/java/com/couchbase/client/util/DurationUtil.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.couchbase.client.util;
+
+import com.couchbase.client.core.annotation.Stability;
+
+import java.time.Duration;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+@Stability.Internal
+public class DurationUtil {
+  private DurationUtil() {
+  }
+
+  public static long toMicros(Duration d) {
+    return NANOSECONDS.toMicros(d.toNanos());
+  }
+
+  public static Duration durationOfMicros(long micros) {
+    return Duration.ofNanos(MICROSECONDS.toNanos(micros));
+  }
+}

--- a/src/main/java/com/couchbase/client/util/OperationsToJson.java
+++ b/src/main/java/com/couchbase/client/util/OperationsToJson.java
@@ -26,11 +26,18 @@ import com.couchbase.client.operations.Operations;
 import com.couchbase.client.operations.RequestEncoding;
 
 import java.time.Duration;
-import java.time.format.DateTimeFormatter;
+import java.time.Instant;
+
+import static com.couchbase.client.util.DurationUtil.toMicros;
 
 @Stability.Internal
 public class OperationsToJson {
-  public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss.SSSX");
+  private OperationsToJson() {
+  }
+
+  public static String toJson(Instant instant) {
+    return instant.toString();
+  }
 
   public static ArrayNode toJson(Operations operation) {
     ArrayNode out = Mapper.createArrayNode();
@@ -44,8 +51,8 @@ public class OperationsToJson {
     ObjectNode out = Mapper.createObjectNode();
     out.put("name", operation.name())
       .put("service", operation.service())
-      .put("start", operation.start().format(FORMATTER))
-      .put("durationUs", operation.duration().toNanos() / 1000);
+      .put("start", toJson(operation.start()))
+      .put("durationUs", toMicros(operation.duration()));
     String statement = operation.statement();
     String documentId = operation.documentId();
     String bucket = operation.bucket();
@@ -81,15 +88,15 @@ public class OperationsToJson {
 
   public static ObjectNode toJson(RequestEncoding op) {
     ObjectNode out = Mapper.createObjectNode();
-    out.put("durationUs", op.duration().toNanos() / 1000)
-      .put("start", op.start().format(FORMATTER));
+    out.put("durationUs", toMicros(op.duration()))
+      .put("start", toJson(op.start()));
     return out;
   }
 
   public static ObjectNode toJson(NetworkCall call) {
     ObjectNode out = Mapper.createObjectNode();
-    out.put("durationUs", call.duration().toNanos() / 1000)
-      .put("start", call.start().format(FORMATTER))
+    out.put("durationUs", toMicros(call.duration()))
+      .put("start", toJson(call.start()))
       .put("host", call.remoteHost())
       .put("port", call.remotePort());
     String durability = call.durability();
@@ -98,7 +105,7 @@ public class OperationsToJson {
     }
     Duration serverDuration = call.serverDuration();
     if (serverDuration != null) {
-      out.put("serverDurationUs", serverDuration.toNanos() / 1000);
+      out.put("serverDurationUs", toMicros(serverDuration));
     }
     return out;
   }


### PR DESCRIPTION
Motivation
----------
The request tracer only cares about points in time, not time zones or hours/minutes/seconds.

LocalDateTime and ZonedDateTime are overkill,
and more expensive because creating them requires
time zone / time of day calculations that
don't matter in this context.

Modifications
-------------
Replace (almost) all usages of LocalDateTime and
ZonedDateTime with Instant.

Rename startLocal() -> startInstant()

In the JSON, use a format compatible with ISO 8601 (delimit time components with colons instead of dashes), and include microseconds since we get them for free with Instant.toString().

Move the remaining ZonedDateTime formatting code
(for creating filename prefixes) into ExampleHandlers.

Add utility methods for converting Durations to/from milliseconds.